### PR TITLE
fix typo in title "Colors of interactive states"

### DIFF
--- a/src/techniques/colors-of-states.md
+++ b/src/techniques/colors-of-states.md
@@ -1,5 +1,5 @@
 ---
-title: Colors of interative states
+title: Colors of interactive states
 description: Define colors for states with sufficient contrast.
 date: '2024-4-15'
 category: basics


### PR DESCRIPTION
I assume that "interative" was a typo